### PR TITLE
Feat/sprint 1 gustavo rbac ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend (test + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: helpdesk
+          POSTGRES_PASSWORD: helpdesk
+          POSTGRES_DB: helpdesk_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://helpdesk:helpdesk@localhost:5432/helpdesk_test?schema=public
+      JWT_SECRET: ci-secret
+      JWT_EXPIRES_IN: 1h
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npx prisma generate
+      # TODO(sprint-2): adicionar step de lint quando ESLint estiver configurado
+      - run: npm test -- --runInBand
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HelpDesk Operacional
 
+![CI](https://github.com/Lucas-Henrique-Lopes-Costa/HelpDesk/actions/workflows/ci.yml/badge.svg?branch=main)
+
 Sistema de gestão de chamados e manutenção de facilities para grandes empresas. Conecta colaboradores (que reportam problemas físicos — manutenção, limpeza, reposição de insumos) à equipe operacional, com validação visual (fotos antes/depois) e controle rigoroso de SLA.
 
 > **Disciplina:** GCC267 - Projeto Integrador I (UFLA, 2026/1)

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -344,6 +344,15 @@ export const openApiSpec = {
               },
             },
           },
+          403: {
+            description: "Usuário autenticado não tem permissão para abrir chamados",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+                example: { error: "FORBIDDEN", message: "Acesso negado" },
+              },
+            },
+          },
           404: {
             description: "Localização ou categoria não encontrada",
             content: {
@@ -391,6 +400,15 @@ export const openApiSpec = {
             content: {
               "application/json": {
                 schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          403: {
+            description: "Usuário autenticado não tem permissão para listar o backlog",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+                example: { error: "FORBIDDEN", message: "Acesso negado" },
               },
             },
           },

--- a/backend/src/middleware/authorize.ts
+++ b/backend/src/middleware/authorize.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import { UserRole } from "@prisma/client";
+import { ForbiddenError, UnauthorizedError } from "../utils/errors";
+
+export function authorize(...roles: UserRole[]) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return next(new UnauthorizedError("Token ausente"));
+    }
+    if (!roles.includes(req.user.role as UserRole)) {
+      return next(new ForbiddenError());
+    }
+    return next();
+  };
+}

--- a/backend/src/routes/ticket.routes.ts
+++ b/backend/src/routes/ticket.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
+import { UserRole } from "@prisma/client";
 import { validateBody } from "../middleware/validate";
 import { authenticate } from "../middleware/authenticate";
+import { authorize } from "../middleware/authorize";
 import {
   createTicketController,
   createTicketSchema,
@@ -13,17 +15,24 @@ const ticketController = createTicketController(ticketService);
 
 export const ticketRouter = Router();
 
-// POST - Criar ticket (autenticado)
-ticketRouter.post("/", authenticate, validateBody(createTicketSchema), (req, res, next) =>
-  ticketController.create(req, res, next),
+// POST - Criar ticket (solicitantes, gestores e admin)
+ticketRouter.post(
+  "/",
+  authenticate,
+  authorize(UserRole.REQUESTER, UserRole.MANAGER, UserRole.ADMIN),
+  validateBody(createTicketSchema),
+  (req, res, next) => ticketController.create(req, res, next),
 );
 
-// GET - Listar tickets (autenticado, com filtros)
-ticketRouter.get("/", authenticate, (req, res, next) =>
-  ticketController.list(req, res, next),
+// GET - Listar tickets (apenas operacional, gestores e admin enxergam o backlog)
+ticketRouter.get(
+  "/",
+  authenticate,
+  authorize(UserRole.MANAGER, UserRole.ADMIN, UserRole.OPERATOR),
+  (req, res, next) => ticketController.list(req, res, next),
 );
 
-// GET - Detalhar ticket específico (autenticado)
+// GET - Detalhar ticket específico (qualquer usuário autenticado; ownership do REQUESTER será aplicada no Sprint 2)
 ticketRouter.get("/:id", authenticate, (req, res, next) =>
   ticketController.getById(req, res, next),
 );

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -26,3 +26,9 @@ export class NotFoundError extends AppError {
     super(message, 404, "NOT_FOUND");
   }
 }
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Acesso negado") {
+    super(message, 403, "FORBIDDEN");
+  }
+}

--- a/backend/tests/unit/auth.middleware.test.ts
+++ b/backend/tests/unit/auth.middleware.test.ts
@@ -1,0 +1,92 @@
+import type { Request, Response, NextFunction } from "express";
+import { UserRole } from "@prisma/client";
+import { authenticate } from "../../src/middleware/authenticate";
+import { authorize } from "../../src/middleware/authorize";
+import { jwtService } from "../../src/config/jwt";
+import { ForbiddenError, UnauthorizedError } from "../../src/utils/errors";
+
+function makeReq(headers: Record<string, string> = {}, user?: Request["user"]): Request {
+  return { headers, user } as unknown as Request;
+}
+
+const noopRes = {} as Response;
+
+describe("authenticate", () => {
+  it("chama next com UnauthorizedError quando não há header Authorization", () => {
+    const req = makeReq();
+    const next = jest.fn() as unknown as NextFunction;
+
+    authenticate(req, noopRes, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((next as jest.Mock).mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("chama next com erro quando o token Bearer é inválido", () => {
+    const req = makeReq({ authorization: "Bearer not-a-valid-jwt" });
+    const next = jest.fn() as unknown as NextFunction;
+
+    authenticate(req, noopRes, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const arg = (next as jest.Mock).mock.calls[0][0];
+    expect(arg).toBeInstanceOf(Error);
+    expect(arg).toBeDefined();
+  });
+
+  it("popula req.user quando o token é válido", () => {
+    const token = jwtService.sign({
+      sub: "user-1",
+      email: "lucas@helpdesk.local",
+      role: "MANAGER",
+    });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const next = jest.fn() as unknown as NextFunction;
+
+    authenticate(req, noopRes, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(req.user).toMatchObject({
+      sub: "user-1",
+      email: "lucas@helpdesk.local",
+      role: "MANAGER",
+    });
+  });
+});
+
+describe("authorize", () => {
+  it("chama next com UnauthorizedError quando req.user está ausente", () => {
+    const req = makeReq();
+    const next = jest.fn() as unknown as NextFunction;
+
+    authorize(UserRole.MANAGER)(req, noopRes, next);
+
+    expect((next as jest.Mock).mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("chama next com ForbiddenError quando a role não está autorizada", () => {
+    const req = makeReq({}, {
+      sub: "user-2",
+      email: "ana@helpdesk.local",
+      role: UserRole.REQUESTER,
+    });
+    const next = jest.fn() as unknown as NextFunction;
+
+    authorize(UserRole.MANAGER)(req, noopRes, next);
+
+    expect((next as jest.Mock).mock.calls[0][0]).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("permite o acesso quando a role bate com qualquer uma das aceitas", () => {
+    const req = makeReq({}, {
+      sub: "user-3",
+      email: "admin@helpdesk.local",
+      role: UserRole.ADMIN,
+    });
+    const next = jest.fn() as unknown as NextFunction;
+
+    authorize(UserRole.MANAGER, UserRole.ADMIN)(req, noopRes, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/docs/retrospectivas/sprint1.md
+++ b/docs/retrospectivas/sprint1.md
@@ -1,0 +1,35 @@
+# Retrospectiva Sprint 1
+
+**Data:** 2026-04-23
+**Participantes:** Lucas, Pedro, Thiago, Gustavo
+**Sprint encerrado em:** 22/04/2026
+
+## O que entregamos
+
+Fechamos as três User Stories planejadas para o Sprint 1, com 1 PR mergeado em `main` por integrante.
+
+- **Lucas** subiu o esqueleto do projeto: estrutura do monorepo (`backend/`, `frontend/`, `docs/`), o `docker-compose.yml` com Postgres, Redis e MinIO, e os dois primeiros ADRs (001 — escolha da stack, e 002 — arquitetura em camadas do backend). Implementou US-01 inteira: cadastro e login com JWT, hash de senha com bcrypt, validação por Zod e os testes unitários de `auth.service` e `hash.service`. Para fechar, escreveu o README e configurou o Swagger UI em `/docs` para a gente conseguir testar os endpoints manualmente.
+- **Pedro** levantou o domínio de chamados em três PRs encadeados (#21, #22, #23): primeiro os models `Ticket`, `Location` e `Category` no Prisma com migrations; depois o `POST /tickets` (US-02 do lado do back); e por fim o `GET /tickets` com filtros (status, prioridade, categoria, local, responsável) + paginação, e o `GET /tickets/:id` para detalhar. Cobriu cada peça com testes do service usando o mesmo padrão de Prisma mockado em memória que o Lucas tinha proposto.
+- **Thiago** fez o frontend em Next.js 14 (App Router) com Tailwind: tela de login ligada no `POST /auth/login` (US-01), dashboard de listagem com filtros (US-03) e o formulário de abertura de chamado (US-02). A branch dele já está pronta no remote (`feat/sprint-1-thiago-frontend`); o PR vai entrar logo após o merge deste de RBAC.
+- **Gustavo** entrei depois com a parte de segurança e de CI: o middleware `authorize(roles)` (que se encaixa com o `authenticate` que o Pedro tinha deixado pronto), a classe de erro `ForbiddenError`, os testes unitários dos dois middlewares, a aplicação do RBAC nas rotas de tickets, o workflow do GitHub Actions rodando teste e build a cada PR e push em `main`, e a badge de status no README.
+
+No fim, a suíte de testes do backend ficou em 27 testes verdes (auth, hash, tickets e middlewares), o `npm run build` passa limpo e o `docker compose up -d` sobe o ambiente local com um comando só.
+
+## Continue
+
+1. **Dividir o backend em routes/controller/service.** Cada um trabalhou no seu trio sem pisar no pé do outro e os PRs fluíram em paralelo, com pouquíssimos conflitos de merge. A regra "service recebe Prisma por parâmetro" foi o que permitiu rodar testes sem subir banco.
+2. **PRs pequenos, um por feature.** O Pedro abriu três PRs separados só para US-02 e isso fez o review do Lucas ser viável. Vamos manter granularidade pequena no Sprint 2.
+3. **Decidir antes de codar.** As ADRs evitaram briga de padrão na hora dos PRs — quando alguém divergia, a gente apontava o ADR e seguia. Quero abrir mais ADRs no Sprint 2 (filas, storage, política de SLA).
+
+## Stop
+
+1. **Issues sem assignee.** A gente perdeu tempo em call só descobrindo "quem ia fazer o que" quando começamos. No Sprint 2 todo mundo assume sua issue no GitHub Project antes de começar a trabalhar.
+2. **Testes manuais sem registro.** Subia, testava no Swagger, dava certo e mergeava — mas não ficou trilha do que foi testado. No Sprint 2 quero ter uma checklist mínima de smoke test no body do PR.
+3. **TODOs no código sem dono nem destino.** Ficou TODO solto que ninguém sabe se vira issue ou se é Sprint 2 mesmo. Padronizar para `// TODO(sprint-2):` e/ou abrir issue correspondente.
+
+## Start
+
+1. **Configurar ESLint + Prettier no backend.** Já deixei o espaço reservado no `ci.yml` com um TODO de Sprint 2. Quero o lint quebrando antes do `npm test`.
+2. **Aplicar checagem de ownership em `GET /tickets/:id`.** Hoje qualquer autenticado vê qualquer ticket. Solicitante deveria ver só os próprios — vai virar issue do Sprint 2.
+3. **Ativar branch protection no `main`.** Exigir PR + 1 aprovação + status check `Backend (test + build)` verde. Hoje, teoricamente, um push direto ainda passaria. Instruções no corpo do PR de RBAC/CI.
+4. **Testes de integração com Postgres real.** O service `postgres` já está no `ci.yml` justamente para isso — falta um job paralelo que rode `prisma migrate deploy` + uma suíte que exercite as constraints de FK (location, category, reporter).


### PR DESCRIPTION
## O que entrega                                                              
                                                                                
  Esta PR fecha as quatro issues do Sprint 1 que estavam sob minha              
  responsabilidade (RBAC, CI e retrospectiva).                                  
                                                                                
  ### Backend — RBAC                                                            
  - `feat(auth)`: adiciona `ForbiddenError` (status 403, code `FORBIDDEN`) em
  `utils/errors.ts` para negações de RBAC.                                      
  - `feat(rbac)`: novo middleware `authorize(...roles)` em
  `middleware/authorize.ts` que checa `req.user.role` e devolve `ForbiddenError`
   (ou `UnauthorizedError` quando não há `req.user`).
  - `feat(rbac)`: aplica `authorize` nas rotas de tickets:                      
    - `POST /tickets` → `REQUESTER`, `MANAGER`, `ADMIN`                         
    - `GET /tickets` → `MANAGER`, `ADMIN`, `OPERATOR`                           
    - `GET /tickets/:id` → qualquer autenticado (ownership do REQUESTER fica    
  para o Sprint 2)                                                              
  - Atualiza `openapi.ts` com responses 403 nos endpoints protegidos.           
                                                                                
  > O middleware `authenticate` já tinha sido implementado pelo Pedro no PR #21 
  (`backend/src/middleware/authenticate.ts`). Este PR só adiciona o `authorize` 
  que faltava para fechar a #16. Por isso optei por criar                       
  `middleware/authorize.ts` num arquivo separado, sem editar o do Pedro.

  ### CI — GitHub Actions
  - `.github/workflows/ci.yml` rodando em todo `pull_request` e `push` em
  `main`:                                                                       
    - service `postgres:16-alpine` (para suítes que vierem a depender de banco)
    - `npm ci` → `npx prisma generate` → `npm test --runInBand` → `npm run      
  build`                                                                        
  - Badge de status no `README.md`.                                             
                                                                                
  > A issue #18 também pedia step de `lint`. Não foi adicionado porque o ESLint 
  ainda não está configurado no projeto. Deixei o passo reservado no `ci.yml`   
  com um `# TODO(sprint-2)` e registrei o item na retrospectiva.                
                  
  ### Testes
  - `tests/unit/auth.middleware.test.ts` cobre 6 cenários:
    - `authenticate` sem header / com Bearer inválido / com token válido (popula
   `req.user`)                                                                  
    - `authorize` sem `req.user` / com role não autorizada / com role aceita    
  - Suíte total: **27 testes verdes**.                                          
                                                                                
  ### Documentação                                                              
  - `docs/retrospectivas/sprint1.md` — formato Continue / Stop / Start, com a   
  contribuição de cada integrante e plano para o Sprint 2.                      
   
  ## Como testar localmente                                                     
                  
  ```bash                                                                       
  cd backend      
  npm ci
  npx prisma generate
  npm test -- --runInBand   # 27 testes verdes
  npm run build             # tsc limpo                                         
  ```
                                                                                
  Smoke test do RBAC:                                                           
  ```bash
  docker compose up -d                                                          
  cd backend && npx prisma migrate dev && npm run dev
                                                                                
  # Sem token → 401
  curl -i -X POST http://localhost:3333/tickets -H 'Content-Type:               
  application/json' -d '{}'                                                     
                                                                                
  # REQUESTER tentando GET /tickets (precisa MANAGER/ADMIN/OPERATOR) → 403      
  TOKEN=$(curl -s -X POST localhost:3333/auth/register -H 'Content-Type:        
  application/json' \                                                           
    -d '{"name":"Ana","email":"ana@helpdesk.local","password":"secret123"}' | jq
   -r .token)                                                                   
  curl -i -H "Authorization: Bearer $TOKEN" http://localhost:3333/tickets
  ```                                                                           
                  
  ## Branch protection no `main` (proposta para o Lucas ativar)                 
                  
  1. `Settings` → `Branches` → `Add rule`                                       
  2. Branch name pattern: `main`
  3. Marcar:                                                                    
     - Require a pull request before merging
     - Require approvals: 1                                                     
     - Require status checks to pass before merging → adicionar **`Backend (test
   + build)`**                                                                  
     - Require branches to be up to date before merging                         
                                                                                
  ## Issues       
                                                                                
  Closes #16      
  Closes #17
  Closes #18
  Closes #19 