### PR TITLE
docs: add frontend setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,28 @@ npm install
 npm run prisma:generate
 npm run prisma:migrate
 npm run dev  # sobe em http://localhost:3333
+
+# 4. Frontend (em outro terminal, na raiz do projeto)
+cd frontend
+cp .env.local.example .env.local
+npm install
+npm run dev  # sobe em http://localhost:3000
 ```
 
-Healthcheck: `curl http://localhost:3333/health`.
+Healthcheck do backend: `curl http://localhost:3333/health`.
+Documentação interativa (Swagger): <http://localhost:3333/docs>.
+Frontend: abra <http://localhost:3000>. As credenciais do seed são `admin@helpdesk.local` / `helpdesk123`.
+
+### Modo mock do frontend (sem backend)
+
+Para navegar pelas telas sem subir Postgres/backend, edite `frontend/.env.local`:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:3333
+NEXT_PUBLIC_USE_MOCK=true
+```
+
+Com o flag ligado, o dashboard usa 5 chamados mockados em memória e o formulário de novo chamado cria registros locais (somem ao recarregar). Útil para demo offline e desenvolvimento de UI.
 
 ## Scripts do backend
 
@@ -69,6 +88,15 @@ Healthcheck: `curl http://localhost:3333/health`.
 | `npm test` | Testes unitários (Jest) |
 | `npm run test:coverage` | Testes + relatório de cobertura |
 | `npm run prisma:migrate` | Aplica migrations no banco |
+
+## Scripts do frontend
+
+| Comando | Descrição |
+|---|---|
+| `npm run dev` | Next.js dev server em <http://localhost:3000> |
+| `npm run build` | Build de produção |
+| `npm run start` | Serve a build |
+| `npm run lint` | ESLint (`next lint`) |
 
 ## Documentação
 


### PR DESCRIPTION
## Resumo

Documenta como rodar o frontend, que estava sem instruções no README após o merge do PR #24.

### Mudanças
- **Passo 4 — Frontend** adicionado no bloco "Como rodar localmente": `cp .env.local.example .env.local`, `npm install`, `npm run dev` (sobe em http://localhost:3000).
- Menção ao Swagger UI em http://localhost:3333/docs e às credenciais do seed (`admin@helpdesk.local` / `helpdesk123`).
- Subseção **"Modo mock do frontend (sem backend)"** explicando o toggle `NEXT_PUBLIC_USE_MOCK=true` para demo offline (útil enquanto Docker/Postgres não estiverem disponíveis localmente).
- Tabela de **scripts do frontend** (`dev` / `build` / `start` / `lint`).

## Test plan
- [x] Renderizar o README no GitHub e conferir formatação dos novos blocos
- [x] Seguir o passo 4 em uma máquina limpa e confirmar que `npm run dev` sobe sem erros
