### PR TITLE
fix(tickets): remove duplicate UserRole import in ticket.routes

### DIFF
--- a/backend/src/routes/ticket.routes.ts
+++ b/backend/src/routes/ticket.routes.ts
@@ -11,7 +11,6 @@ import {
 } from "../controllers/ticket.controller";
 import { createTicketService } from "../services/ticket.service";
 import { prisma } from "../config/prisma";
-import { UserRole } from "@prisma/client";
 
 const ticketService = createTicketService(prisma);
 const ticketController = createTicketController(ticketService);


### PR DESCRIPTION
## Resumo

Após o merge do PR #27 (issue #11 — máquina de estados de tickets), o arquivo `backend/src/routes/ticket.routes.ts` ficou com `import { UserRole } from "@prisma/client";` **duplicado** (linhas 2 e 14). Este PR remove a duplicata.

## Por que isso aconteceu

PR #27 fez merge da `main` para `feature/branch-pedro` (commit `d80f6de`); a `main` já tinha o import do `UserRole` no topo (vindo do trabalho do Gustavo de RBAC), e o branch do Pedro adicionou outro no fim do bloco de imports. O resolvedor de conflitos manteve os dois.

## Mudança
- Remove a segunda ocorrência (linha 14). A primeira (linha 2) permanece e é usada nos `authorize(UserRole.…)` das rotas.

## Test plan
- [x] `npm run lint` no backend (sem warnings de import duplicado)
- [x] `npm test` continua verde
- [x] Build passa
