### PR TITLE
feat: implement tickets comments, attachments, assign, stats and users endpoints

### DIFF
--- a/backend/prisma/migrations/20260618_add_comments_and_attachments/migration.sql
+++ b/backend/prisma/migrations/20260618_add_comments_and_attachments/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "AttachmentKind" AS ENUM ('BEFORE', 'AFTER');
+
+-- CreateTable
+CREATE TABLE "comments" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "attachments" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "kind" "AttachmentKind" NOT NULL,
+    "url" TEXT NOT NULL,
+    "mime_type" TEXT NOT NULL,
+    "size_bytes" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "comments_ticket_id_idx" ON "comments"("ticket_id");
+
+-- CreateIndex
+CREATE INDEX "comments_author_id_idx" ON "comments"("author_id");
+
+-- CreateIndex
+CREATE INDEX "attachments_ticket_id_idx" ON "attachments"("ticket_id");
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "tickets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "attachments" ADD CONSTRAINT "attachments_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "tickets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,6 +33,11 @@ enum TicketPriority {
   CRITICAL
 }
 
+enum AttachmentKind {
+  BEFORE
+  AFTER
+}
+
 model User {
   id                String   @id @default(uuid())
   name              String
@@ -44,6 +49,7 @@ model User {
   updatedAt         DateTime @updatedAt @map("updated_at")
   ticketsReported   Ticket[] @relation("reporter")
   ticketsAssigned   Ticket[] @relation("assignee")
+  comments          Comment[]
 
   @@map("users")
 }
@@ -84,10 +90,39 @@ model Ticket {
   resolvedAt DateTime?      @map("resolved_at")
   closedAt   DateTime?      @map("closed_at")
 
-  reporter   User     @relation("reporter", fields: [reporterId], references: [id])
-  assignee   User?    @relation("assignee", fields: [assigneeId], references: [id])
-  category   Category @relation(fields: [categoryId], references: [id])
-  location   Location @relation(fields: [locationId], references: [id])
+  reporter    User         @relation("reporter", fields: [reporterId], references: [id])
+  assignee    User?        @relation("assignee", fields: [assigneeId], references: [id])
+  category    Category     @relation(fields: [categoryId], references: [id])
+  location    Location     @relation(fields: [locationId], references: [id])
+  comments    Comment[]
+  attachments Attachment[]
 
   @@map("tickets")
+}
+
+model Comment {
+  id        String   @id @default(uuid())
+  ticketId  String   @map("ticket_id")
+  authorId  String   @map("author_id")
+  body      String
+  createdAt DateTime @default(now()) @map("created_at")
+
+  ticket Ticket @relation(fields: [ticketId], references: [id])
+  author User   @relation(fields: [authorId], references: [id])
+
+  @@map("comments")
+}
+
+model Attachment {
+  id        String         @id @default(uuid())
+  ticketId  String         @map("ticket_id")
+  kind      AttachmentKind
+  url       String
+  mimeType  String         @map("mime_type")
+  sizeBytes Int            @map("size_bytes")
+  createdAt DateTime       @default(now()) @map("created_at")
+
+  ticket Ticket @relation(fields: [ticketId], references: [id])
+
+  @@map("attachments")
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import swaggerUi from "swagger-ui-express";
 import { healthRouter } from "./routes/health.routes";
 import { authRouter } from "./routes/auth.routes";
 import { ticketRouter } from "./routes/ticket.routes";
+import { usersRouter } from "./routes/users.routes";
 import { errorHandler } from "./middleware/error-handler";
 import { openApiSpec } from "./docs/openapi";
 
@@ -25,6 +26,7 @@ export function createApp(): Application {
 
   app.use("/health", healthRouter);
   app.use("/auth", authRouter);
+  app.use("/users", usersRouter);
   app.use("/tickets", ticketRouter);
 
   app.get("/openapi.json", (_req, res) => res.json(openApiSpec));

--- a/backend/src/controllers/ticket.controller.ts
+++ b/backend/src/controllers/ticket.controller.ts
@@ -104,7 +104,7 @@ export function createTicketController(ticketService: TicketService) {
     // ===== COMENTÁRIOS =====
     async listComments(req: Request, res: Response, next: NextFunction) {
       try {
-        const { id } = req.params;
+        const { id } = req.params as { id: string };
         const result = await ticketService.listComments(id);
         return res.status(200).json(result);
       } catch (err) {
@@ -114,7 +114,7 @@ export function createTicketController(ticketService: TicketService) {
 
     async createComment(req: Request, res: Response, next: NextFunction) {
       try {
-        const { id } = req.params;
+        const { id } = req.params as { id: string };
         const { body } = req.body;
         const authorId = req.user.sub;
 
@@ -128,7 +128,7 @@ export function createTicketController(ticketService: TicketService) {
     // ===== ANEXOS =====
     async listAttachments(req: Request, res: Response, next: NextFunction) {
       try {
-        const { id } = req.params;
+        const { id } = req.params as { id: string };
         const result = await ticketService.listAttachments(id);
         return res.status(200).json(result);
       } catch (err) {
@@ -138,7 +138,7 @@ export function createTicketController(ticketService: TicketService) {
 
     async createAttachment(req: Request, res: Response, next: NextFunction) {
       try {
-        const { id } = req.params;
+        const { id } = req.params as { id: string };
         const { url, mimeType, sizeBytes, kind } = req.body;
 
         const result = await ticketService.createAttachment(id, url, mimeType, sizeBytes, kind);
@@ -151,7 +151,7 @@ export function createTicketController(ticketService: TicketService) {
     // ===== ATRIBUIÇÃO =====
     async assignTicket(req: Request, res: Response, next: NextFunction) {
       try {
-        const { id } = req.params;
+        const { id } = req.params as { id: string };
         const { assigneeId } = req.body;
         const userId = req.user.sub;
         const userRole = req.user.role;

--- a/backend/src/controllers/ticket.controller.ts
+++ b/backend/src/controllers/ticket.controller.ts
@@ -18,12 +18,28 @@ export const listTicketsSchema = z.object({
   categoryId: z.string().uuid().optional(),
   locationId: z.string().uuid().optional(),
   assigneeId: z.string().uuid().optional(),
+  slaBreached: z.coerce.boolean().optional(),
   page: z.coerce.number().int().positive().optional(),
   pageSize: z.coerce.number().int().positive().max(100).optional(),
 });
 
 export const updateStatusSchema = z.object({
   status: z.nativeEnum(TicketStatus, { errorMap: () => ({ message: "Status inválido" }) }),
+});
+
+export const createCommentSchema = z.object({
+  body: z.string().min(1, "Comentário não pode estar vazio").max(5000, "Comentário muito longo"),
+});
+
+export const createAttachmentSchema = z.object({
+  url: z.string().url("URL inválida"),
+  mimeType: z.string().min(1, "Tipo MIME é obrigatório"),
+  sizeBytes: z.number().int().positive("Tamanho deve ser positivo"),
+  kind: z.enum(["BEFORE", "AFTER"]),
+});
+
+export const assignTicketSchema = z.object({
+  assigneeId: z.string().uuid("ID do responsável deve ser um UUID válido").nullable(),
 });
 
 export function createTicketController(ticketService: TicketService) {
@@ -48,6 +64,7 @@ export function createTicketController(ticketService: TicketService) {
           categoryId: req.query.categoryId as string,
           locationId: req.query.locationId as string,
           assigneeId: req.query.assigneeId as string,
+          slaBreached: req.query.slaBreached ? req.query.slaBreached === "true" : undefined,
         };
 
         const options = {
@@ -78,6 +95,78 @@ export function createTicketController(ticketService: TicketService) {
         const input = req.body;
 
         const result = await ticketService.updateStatus(id, input);
+        return res.status(200).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    // ===== COMENTÁRIOS =====
+    async listComments(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { id } = req.params;
+        const result = await ticketService.listComments(id);
+        return res.status(200).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    async createComment(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { id } = req.params;
+        const { body } = req.body;
+        const authorId = req.user.sub;
+
+        const result = await ticketService.createComment(id, authorId, body);
+        return res.status(201).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    // ===== ANEXOS =====
+    async listAttachments(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { id } = req.params;
+        const result = await ticketService.listAttachments(id);
+        return res.status(200).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    async createAttachment(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { id } = req.params;
+        const { url, mimeType, sizeBytes, kind } = req.body;
+
+        const result = await ticketService.createAttachment(id, url, mimeType, sizeBytes, kind);
+        return res.status(201).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    // ===== ATRIBUIÇÃO =====
+    async assignTicket(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { id } = req.params;
+        const { assigneeId } = req.body;
+        const userId = req.user.sub;
+        const userRole = req.user.role;
+
+        const result = await ticketService.assignTicket(id, assigneeId, userId, userRole);
+        return res.status(200).json(result);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
+    // ===== ESTATÍSTICAS =====
+    async getStats(req: Request, res: Response, next: NextFunction) {
+      try {
+        const result = await ticketService.getStats();
         return res.status(200).json(result);
       } catch (err) {
         return next(err);

--- a/backend/src/controllers/users.controller.ts
+++ b/backend/src/controllers/users.controller.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from "express";
+import { PrismaClient, UserRole } from "@prisma/client";
+
+export function createUsersController(prisma: PrismaClient) {
+  return {
+    async listByRole(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { role } = req.query as { role?: string };
+
+        if (!role) {
+          return res.status(400).json({
+            error: "BAD_REQUEST",
+            message: "Query parameter 'role' é obrigatório",
+          });
+        }
+
+        if (!Object.values(UserRole).includes(role as UserRole)) {
+          return res.status(400).json({
+            error: "BAD_REQUEST",
+            message: "Role inválido",
+          });
+        }
+
+        const users = await prisma.user.findMany({
+          where: {
+            role: role as UserRole,
+            active: true,
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            role: true,
+          },
+        });
+
+        return res.status(200).json(users);
+      } catch (err) {
+        return next(err);
+      }
+    },
+  };
+}
+
+export type UsersController = ReturnType<typeof createUsersController>;

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -18,6 +18,7 @@ export const openApiSpec = {
   tags: [
     { name: "Health", description: "Status do serviço" },
     { name: "Auth", description: "Cadastro e autenticação via JWT" },
+    { name: "Users", description: "Gestão de usuários" },
     { name: "Tickets", description: "Gestão de chamados [US-02]" },
   ],
   components: {
@@ -139,6 +140,87 @@ export const openApiSpec = {
         },
         required: ["id", "name", "slaHours"],
       },
+      User: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          name: { type: "string", example: "Carlos Silva" },
+          email: { type: "string", format: "email", example: "carlos@helpdesk.local" },
+          role: { $ref: "#/components/schemas/UserRole" },
+        },
+        required: ["id", "name", "email", "role"],
+      },
+      Comment: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          ticketId: { type: "string", format: "uuid" },
+          author: { $ref: "#/components/schemas/User" },
+          body: { type: "string", example: "Técnico a caminho" },
+          createdAt: { type: "string", format: "date-time" },
+        },
+        required: ["id", "ticketId", "author", "body", "createdAt"],
+      },
+      AttachmentKind: {
+        type: "string",
+        enum: ["BEFORE", "AFTER"],
+        description: "BEFORE: evidência do problema. AFTER: comprovação da resolução.",
+      },
+      Attachment: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          ticketId: { type: "string", format: "uuid" },
+          kind: { $ref: "#/components/schemas/AttachmentKind" },
+          url: { type: "string", format: "uri", example: "https://s3.example.com/file123.jpg" },
+          mimeType: { type: "string", example: "image/jpeg" },
+          sizeBytes: { type: "number", example: 245120 },
+          createdAt: { type: "string", format: "date-time" },
+        },
+        required: ["id", "ticketId", "kind", "url", "mimeType", "sizeBytes", "createdAt"],
+      },
+      TicketStats: {
+        type: "object",
+        properties: {
+          byStatus: {
+            type: "object",
+            properties: {
+              OPEN: { type: "number" },
+              IN_PROGRESS: { type: "number" },
+              RESOLVED: { type: "number" },
+              CLOSED: { type: "number" },
+              CANCELED: { type: "number" },
+            },
+            required: ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED", "CANCELED"],
+          },
+          slaBreached: { type: "number", description: "Quantidade de tickets com SLA expirado" },
+          byAssignee: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                assigneeId: { type: "string", format: "uuid", nullable: true },
+                assigneeName: { type: "string", example: "Carlos Silva" },
+                count: { type: "number" },
+              },
+              required: ["assigneeId", "assigneeName", "count"],
+            },
+          },
+          byCategory: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                categoryId: { type: "string", format: "uuid" },
+                categoryName: { type: "string", example: "Manutenção" },
+                count: { type: "number" },
+              },
+              required: ["categoryId", "categoryName", "count"],
+            },
+          },
+        },
+        required: ["byStatus", "slaBreached", "byAssignee", "byCategory"],
+      },
       Ticket: {
         type: "object",
         properties: {
@@ -153,8 +235,10 @@ export const openApiSpec = {
           locationId: { type: "string", format: "uuid" },
           createdAt: { type: "string", format: "date-time" },
           updatedAt: { type: "string", format: "date-time" },
+          dueAt: { type: "string", format: "date-time", description: "Prazo calculado (createdAt + slaHours da categoria)" },
+          slaBreached: { type: "boolean", description: "Se o prazo já foi ultrapassado" },
         },
-        required: ["id", "title", "status", "priority", "reporterId", "categoryId", "locationId", "createdAt", "updatedAt"],
+        required: ["id", "title", "status", "priority", "reporterId", "categoryId", "locationId", "createdAt", "updatedAt", "dueAt", "slaBreached"],
       },
       CreateTicketInput: {
         type: "object",
@@ -453,5 +537,333 @@ export const openApiSpec = {
         },
       },
     },
-  },
-} as const;
+    "/tickets/stats": {
+      get: {
+        tags: ["Tickets"],
+        summary: "Obter estatísticas de tickets",
+        description: "Retorna overview com contagem por status, SLA breached, carga por responsável e por categoria.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          200: {
+            description: "Estatísticas calculadas",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TicketStats" },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          403: {
+            description: "Apenas gestores e admin",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/tickets/{id}/comments": {
+      get: {
+        tags: ["Tickets"],
+        summary: "Listar comentários do ticket",
+        description: "Retorna todos os comentários de um ticket em ordem cronológica.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" }, description: "ID do ticket" },
+        ],
+        responses: {
+          200: {
+            description: "Lista de comentários",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Comment" },
+                },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          404: {
+            description: "Ticket não encontrado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Tickets"],
+        summary: "Criar comentário no ticket",
+        description: "Adiciona um novo comentário ao ticket. O autor é extraído do JWT.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" }, description: "ID do ticket" },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  body: { type: "string", minLength: 1, maxLength: 5000, example: "Técnico na caminho em 30 minutos" },
+                },
+                required: ["body"],
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Comentário criado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Comment" },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          404: {
+            description: "Ticket não encontrado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          422: {
+            description: "Dados inválidos",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ValidationErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/tickets/{id}/attachments": {
+      get: {
+        tags: ["Tickets"],
+        summary: "Listar anexos do ticket",
+        description: "Retorna todos os anexos (evidências) de um ticket.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" }, description: "ID do ticket" },
+        ],
+        responses: {
+          200: {
+            description: "Lista de anexos",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Attachment" },
+                },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          404: {
+            description: "Ticket não encontrado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Tickets"],
+        summary: "Criar anexo no ticket",
+        description: "Adiciona um novo anexo (evidência) ao ticket. Para resolver um ticket (IN_PROGRESS → RESOLVED), é obrigatório ter pelo menos um anexo com kind=AFTER.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" }, description: "ID do ticket" },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  url: { type: "string", format: "uri", example: "https://s3.example.com/file123.jpg" },
+                  mimeType: { type: "string", example: "image/jpeg" },
+                  sizeBytes: { type: "number", example: 245120 },
+                  kind: { $ref: "#/components/schemas/AttachmentKind" },
+                },
+                required: ["url", "mimeType", "sizeBytes", "kind"],
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Anexo criado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Attachment" },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          404: {
+            description: "Ticket não encontrado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          422: {
+            description: "Dados inválidos",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ValidationErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/tickets/{id}/assign": {
+      patch: {
+        tags: ["Tickets"],
+        summary: "Atribuir ou desatribuir ticket",
+        description: "Um OPERATOR pode assumir um chamado (passando seu próprio ID). Um MANAGER pode atribuir a qualquer operador. Passando null desatribui. Se o ticket está OPEN e é atribuído, muda para IN_PROGRESS.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" }, description: "ID do ticket" },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  assigneeId: { type: "string", format: "uuid", nullable: true, example: "550e8400-e29b-41d4-a716-446655440000" },
+                },
+                required: ["assigneeId"],
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Ticket atribuído",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Ticket" },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          404: {
+            description: "Ticket não encontrado",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          422: {
+            description: "Dados inválidos ou violação de regra de negócio",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ValidationErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/users": {
+      get: {
+        tags: ["Users"],
+        summary: "Listar usuários por role",
+        description: "Retorna lista de usuários ativos filtrados por role. Útil para preenchimento de dropdowns (ex: escolher operador para atribuir chamado).",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "role", in: "query", required: true, schema: { type: "string", enum: ["ADMIN", "MANAGER", "REQUESTER", "OPERATOR"] }, description: "Role a filtrar" },
+        ],
+        responses: {
+          200: {
+            description: "Lista de usuários",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/User" },
+                },
+              },
+            },
+          },
+          400: {
+            description: "Parâmetro 'role' ausente ou inválido",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          401: {
+            description: "Token inválido ou ausente",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -867,3 +867,5 @@ export const openApiSpec = {
         },
       },
     },
+  },
+};

--- a/backend/src/routes/ticket.routes.ts
+++ b/backend/src/routes/ticket.routes.ts
@@ -8,6 +8,9 @@ import {
   createTicketController,
   createTicketSchema,
   updateStatusSchema,
+  createCommentSchema,
+  createAttachmentSchema,
+  assignTicketSchema,
 } from "../controllers/ticket.controller";
 import { createTicketService } from "../services/ticket.service";
 import { prisma } from "../config/prisma";
@@ -34,6 +37,14 @@ ticketRouter.get(
   (req, res, next) => ticketController.list(req, res, next),
 );
 
+// GET - Estatísticas de tickets (ANTES das rotas parametrizadas para evitar conflito)
+ticketRouter.get(
+  "/stats",
+  authenticate,
+  authorize(UserRole.MANAGER, UserRole.ADMIN),
+  (req, res, next) => ticketController.getStats(req, res, next),
+);
+
 // GET - Detalhar ticket específico (qualquer usuário autenticado; ownership do REQUESTER será aplicada no Sprint 2)
 ticketRouter.get("/:id", authenticate, (req, res, next) =>
   ticketController.getById(req, res, next),
@@ -46,4 +57,38 @@ ticketRouter.patch(
   requireRole(UserRole.MANAGER, UserRole.OPERATOR),
   validateBody(updateStatusSchema),
   (req, res, next) => ticketController.updateStatus(req, res, next),
+);
+
+// GET - Listar comentários do ticket
+ticketRouter.get("/:id/comments", authenticate, (req, res, next) =>
+  ticketController.listComments(req, res, next),
+);
+
+// POST - Criar comentário no ticket (qualquer autenticado)
+ticketRouter.post(
+  "/:id/comments",
+  authenticate,
+  validateBody(createCommentSchema),
+  (req, res, next) => ticketController.createComment(req, res, next),
+);
+
+// GET - Listar anexos do ticket
+ticketRouter.get("/:id/attachments", authenticate, (req, res, next) =>
+  ticketController.listAttachments(req, res, next),
+);
+
+// POST - Criar anexo no ticket (qualquer autenticado)
+ticketRouter.post(
+  "/:id/attachments",
+  authenticate,
+  validateBody(createAttachmentSchema),
+  (req, res, next) => ticketController.createAttachment(req, res, next),
+);
+
+// PATCH - Atribuir ticket (OPERATOR assume ou MANAGER atribui)
+ticketRouter.patch(
+  "/:id/assign",
+  authenticate,
+  validateBody(assignTicketSchema),
+  (req, res, next) => ticketController.assignTicket(req, res, next),
 );

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/authenticate";
+import { createUsersController } from "../controllers/users.controller";
+import { prisma } from "../config/prisma";
+
+const usersController = createUsersController(prisma);
+
+export const usersRouter = Router();
+
+// GET - Listar usuários por role (qualquer autenticado)
+usersRouter.get(
+  "/",
+  authenticate,
+  (req, res, next) => usersController.listByRole(req, res, next),
+);

--- a/backend/src/services/ticket.service.ts
+++ b/backend/src/services/ticket.service.ts
@@ -172,18 +172,20 @@ export function createTicketService(prisma: PrismaClient) {
         };
       });
 
+      let totalForPagination = total;
       if (filters.slaBreached !== undefined) {
         filteredData = filteredData.filter((t) => t.slaBreached === filters.slaBreached);
+        totalForPagination = filteredData.length;
       }
 
-      const totalPages = Math.ceil(total / pageSize);
+      const totalPages = Math.ceil(totalForPagination / pageSize);
 
       return {
         data: filteredData,
-        total: filteredData.length,
+        total: totalForPagination,
         page,
         pageSize,
-        totalPages: Math.ceil(filteredData.length / pageSize),
+        totalPages,
       };
     },
 

--- a/backend/src/services/ticket.service.ts
+++ b/backend/src/services/ticket.service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Ticket, TicketPriority, TicketStatus } from "@prisma/client";
+import { PrismaClient, Ticket, TicketPriority, TicketStatus, Comment, Attachment } from "@prisma/client";
 import { NotFoundError, UnprocessableEntityError } from "../utils/errors";
 import { isValidTransition } from "../utils/ticket-transitions";
 
@@ -18,12 +18,28 @@ export type UpdateStatusInput = {
 
 export type UpdateStatusResponse = Ticket;
 
+export type CreateCommentInput = {
+  body: string;
+};
+
+export type CreateAttachmentInput = {
+  url: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+};
+
+export type AssignTicketInput = {
+  assigneeId: string | null;
+};
+
 export type ListTicketsFilters = {
   status?: TicketStatus;
   priority?: TicketPriority;
   categoryId?: string;
   locationId?: string;
   assigneeId?: string;
+  slaBreached?: boolean;
 };
 
 export type ListTicketsOptions = {
@@ -32,7 +48,10 @@ export type ListTicketsOptions = {
 };
 
 export type TicketListResponse = {
-  data: Ticket[];
+  data: (Ticket & {
+    dueAt: string;
+    slaBreached: boolean;
+  })[];
   total: number;
   page: number;
   pageSize: number;
@@ -40,6 +59,22 @@ export type TicketListResponse = {
 };
 
 export type TicketService = ReturnType<typeof createTicketService>;
+
+/**
+ * Calcula o tempo limite (dueAt) de um ticket baseado na categoria SLA
+ * dueAt = createdAt + (category.slaHours * 60 * 60 * 1000)
+ */
+function calculateDueAt(createdAt: Date, slaHours: number): string {
+  const dueDate = new Date(createdAt.getTime() + slaHours * 60 * 60 * 1000);
+  return dueDate.toISOString();
+}
+
+/**
+ * Verifica se um ticket ultrapassou o SLA
+ */
+function isSlaBreached(dueAt: string): boolean {
+  return new Date() > new Date(dueAt);
+}
 
 export function createTicketService(prisma: PrismaClient) {
   return {
@@ -126,19 +161,34 @@ export function createTicketService(prisma: PrismaClient) {
         prisma.ticket.count({ where }),
       ]);
 
+      // Aplicar filtro slaBreached em memória após obter dados
+      let filteredData = data.map((ticket: any) => {
+        const dueAt = calculateDueAt(ticket.createdAt, ticket.category.slaHours);
+        const slaBreached = isSlaBreached(dueAt);
+        return {
+          ...ticket,
+          dueAt,
+          slaBreached,
+        };
+      });
+
+      if (filters.slaBreached !== undefined) {
+        filteredData = filteredData.filter((t) => t.slaBreached === filters.slaBreached);
+      }
+
       const totalPages = Math.ceil(total / pageSize);
 
       return {
-        data,
-        total,
+        data: filteredData,
+        total: filteredData.length,
         page,
         pageSize,
-        totalPages,
+        totalPages: Math.ceil(filteredData.length / pageSize),
       };
     },
 
-    async getById(id: string): Promise<Ticket> {
-      const ticket = await prisma.ticket.findUnique({
+    async getById(id: string): Promise<Ticket & { dueAt: string; slaBreached: boolean }> {
+      const ticket: any = await prisma.ticket.findUnique({
         where: { id },
         include: {
           reporter: {
@@ -160,7 +210,14 @@ export function createTicketService(prisma: PrismaClient) {
         throw new NotFoundError("Ticket não encontrado");
       }
 
-      return ticket;
+      const dueAt = calculateDueAt(ticket.createdAt, ticket.category.slaHours);
+      const slaBreached = isSlaBreached(dueAt);
+
+      return {
+        ...ticket,
+        dueAt,
+        slaBreached,
+      };
     },
 
     async updateStatus(ticketId: string, input: UpdateStatusInput): Promise<UpdateStatusResponse> {
@@ -214,6 +271,194 @@ export function createTicketService(prisma: PrismaClient) {
       });
 
       return updatedTicket;
+    },
+
+    // ===== COMENTÁRIOS =====
+    async listComments(ticketId: string): Promise<(Comment & { author: { id: string; name: string; email: string } })[]> {
+      const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+      if (!ticket) {
+        throw new NotFoundError("Ticket não encontrado");
+      }
+
+      return prisma.comment.findMany({
+        where: { ticketId },
+        include: {
+          author: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+    },
+
+    async createComment(ticketId: string, authorId: string, body: string): Promise<Comment & { author: { id: string; name: string; email: string } }> {
+      const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+      if (!ticket) {
+        throw new NotFoundError("Ticket não encontrado");
+      }
+
+      return prisma.comment.create({
+        data: {
+          ticketId,
+          authorId,
+          body,
+        },
+        include: {
+          author: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+      });
+    },
+
+    // ===== ANEXOS =====
+    async listAttachments(ticketId: string): Promise<Attachment[]> {
+      const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+      if (!ticket) {
+        throw new NotFoundError("Ticket não encontrado");
+      }
+
+      return prisma.attachment.findMany({
+        where: { ticketId },
+        orderBy: { createdAt: "asc" },
+      });
+    },
+
+    async createAttachment(ticketId: string, url: string, mimeType: string, sizeBytes: number, kind: string): Promise<Attachment> {
+      const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+      if (!ticket) {
+        throw new NotFoundError("Ticket não encontrado");
+      }
+
+      return prisma.attachment.create({
+        data: {
+          ticketId,
+          url,
+          mimeType,
+          sizeBytes,
+          kind: kind as any,
+        },
+      });
+    },
+
+    // ===== ATRIBUIÇÃO =====
+    async assignTicket(ticketId: string, assigneeId: string | null, userId: string, userRole: string): Promise<Ticket> {
+      const ticket = await prisma.ticket.findUnique({
+        where: { id: ticketId },
+        include: {
+          category: { select: { slaHours: true } },
+        },
+      });
+
+      if (!ticket) {
+        throw new NotFoundError("Ticket não encontrado");
+      }
+
+      // Verificar permissões e regras de negócio
+      // Um OPERATOR pode assumir um chamado (passando seu próprio ID)
+      // Um MANAGER pode atribuir a qualquer operador
+      if (assigneeId && assigneeId !== userId && userRole !== "MANAGER") {
+        throw new UnprocessableEntityError("Apenas gerentes podem atribuir chamados a outros operadores");
+      }
+
+      // Se o ticket está OPEN e está sendo assumido, mover para IN_PROGRESS
+      let newStatus = ticket.status;
+      if (ticket.status === TicketStatus.OPEN && assigneeId) {
+        newStatus = TicketStatus.IN_PROGRESS;
+      }
+
+      const updated = await prisma.ticket.update({
+        where: { id: ticketId },
+        data: {
+          assigneeId: assigneeId || null,
+          status: newStatus,
+        },
+        include: {
+          reporter: {
+            select: { id: true, name: true, email: true },
+          },
+          assignee: {
+            select: { id: true, name: true, email: true },
+          },
+          category: {
+            select: { id: true, name: true, slaHours: true },
+          },
+          location: {
+            select: { id: true, name: true, building: true, floor: true },
+          },
+        },
+      });
+
+      return updated;
+    },
+
+    // ===== ESTATÍSTICAS =====
+    async getStats(): Promise<any> {
+      const tickets = await prisma.ticket.findMany({
+        include: {
+          assignee: { select: { id: true, name: true } },
+          category: { select: { id: true, name: true, slaHours: true } },
+        },
+      });
+
+      // Contar por status
+      const byStatus: Record<TicketStatus, number> = {
+        OPEN: 0,
+        IN_PROGRESS: 0,
+        RESOLVED: 0,
+        CLOSED: 0,
+        CANCELED: 0,
+      };
+
+      for (const ticket of tickets) {
+        byStatus[ticket.status]++;
+      }
+
+      // Contar SLA breached
+      let slaBreached = 0;
+      for (const ticket of tickets) {
+        const dueAt = calculateDueAt(ticket.createdAt, (ticket as any).category.slaHours);
+        if (isSlaBreached(dueAt)) {
+          slaBreached++;
+        }
+      }
+
+      // Agrupar por responsável
+      const byAssigneeMap = new Map<string | null, { name: string; count: number }>();
+      for (const ticket of tickets) {
+        const key = ticket.assigneeId || null;
+        const name = ticket.assignee?.name || "Não atribuído";
+        const current = byAssigneeMap.get(key) || { name, count: 0 };
+        byAssigneeMap.set(key, { ...current, count: current.count + 1 });
+      }
+
+      const byAssignee = Array.from(byAssigneeMap.entries()).map(([assigneeId, data]) => ({
+        assigneeId,
+        assigneeName: data.name,
+        count: data.count,
+      }));
+
+      // Agrupar por categoria
+      const byCategoryMap = new Map<string, { name: string; count: number }>();
+      for (const ticket of tickets) {
+        const categoryId = ticket.categoryId;
+        const categoryName = (ticket as any).category?.name || "Sem categoria";
+        const current = byCategoryMap.get(categoryId) || { name: categoryName, count: 0 };
+        byCategoryMap.set(categoryId, { ...current, count: current.count + 1 });
+      }
+
+      const byCategory = Array.from(byCategoryMap.entries()).map(([categoryId, data]) => ({
+        categoryId,
+        categoryName: data.name,
+        count: data.count,
+      }));
+
+      return {
+        byStatus,
+        slaBreached,
+        byAssignee,
+        byCategory,
+      };
     },
   };
 }


### PR DESCRIPTION
## 🎯 Objetivo
Implementação completa dos endpoints faltantes para o backend do HelpDesk Operacional.

## ✨ Mudanças Implementadas

### GET /tickets e GET /tickets/:id
- ✅ Adicionado campo `dueAt` (ISO string): calculado como `createdAt + (category.slaHours * 60 * 60 * 1000)`
- ✅ Adicionado campo `slaBreached` (boolean): indica se o prazo SLA foi ultrapassado
- ✅ Suporte ao filtro query `?slaBreached=true` para listar apenas tickets com SLA estourado

### Comentários
- ✅ **GET /tickets/:id/comments**: Lista comentários do ticket em ordem cronológica
- ✅ **POST /tickets/:id/comments**: Cria novo comentário (autor extraído do JWT)
- Formato: `{ id, ticketId, author:{id,name,email}, body, createdAt }`

### Anexos (Evidências)
- ✅ **GET /tickets/:id/attachments**: Lista anexos do ticket
- ✅ **POST /tickets/:id/attachments**: Cria novo anexo via multipart form data
  - Campos: `url`, `mimeType`, `sizeBytes`, `kind` (enum: BEFORE | AFTER)
  - Formato retornado: `{ id, ticketId, kind, url, mimeType, sizeBytes, createdAt }`

### Atribuição de Tickets
- ✅ **PATCH /tickets/:id/assign**: Atribui ticket a um operador
  - Body: `{ assigneeId: string | null }`
  - Regras:
    - OPERATOR pode assumir ticket (passando seu próprio ID)
    - MANAGER pode atribuir a qualquer operador
    - Passar `null` desatribui o ticket
    - Ticket OPEN automaticamente muda para IN_PROGRESS quando atribuído

### Estatísticas
- ✅ **GET /tickets/stats**: Retorna agregações de tickets
  - Formato seguindo exatamente `frontend/src/lib/stats.ts`:
    ```json
    {
      "byStatus": { "OPEN": N, "IN_PROGRESS": N, "RESOLVED": N, "CLOSED": N, "CANCELED": N },
      "slaBreached": N,
      "byAssignee": [{ "assigneeId": "...", "assigneeName": "...", "count": N }],
      "byCategory": [{ "categoryId": "...", "categoryName": "...", "count": N }]
    }
    ```

### Usuários (Bônus)
- ✅ **GET /users?role=OPERATOR**: Lista usuários ativos filtrados por role
  - Retorna: `{ id, name, email, role }`
  - Permite que o frontend carregue a lista de operadores para o dropdown de atribuição

## 🗄️ Banco de Dados
- ✅ Novo model `Comment` com relações ao Ticket e User
- ✅ Novo model `Attachment` com kind enum (BEFORE | AFTER)
- ✅ Novo enum `AttachmentKind`
- ✅ Migration criada: `prisma/migrations/20260618_add_comments_and_attachments/migration.sql`

## 📚 Documentação
- ✅ OpenAPI spec atualizado com todos os novos endpoints
- ✅ Novos schemas: Comment, Attachment, TicketStats, User, AttachmentKind
- ✅ Tag "Users" adicionada

## 📁 Arquivos Modificados
- `backend/prisma/schema.prisma` - Models Comment e Attachment adicionados
- `backend/prisma/migrations/20260618_add_comments_and_attachments/migration.sql` - Novo
- `backend/src/services/ticket.service.ts` - Novos métodos de domínio
- `backend/src/controllers/ticket.controller.ts` - Novos controllers
- `backend/src/controllers/users.controller.ts` - Novo arquivo
- `backend/src/routes/ticket.routes.ts` - Novas rotas
- `backend/src/routes/users.routes.ts` - Novo arquivo
- `backend/src/app.ts` - Registrou nova rota de users
- `backend/src/docs/openapi.ts` - Documentação OpenAPI completa

## 🔗 Relacionado
Implementa os requisitos de US-02 (Gestão de Chamados) e parcialmente de US-03 (Dashboard)