### PR TITLE
fix(docker): instala openssl para o Prisma rodar no Alpine

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,9 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
+# Prisma precisa de OpenSSL/libc6-compat para detectar o engine correto no Alpine (musl).
+RUN apk add --no-cache openssl libc6-compat
+
 COPY package*.json ./
 RUN npm ci
 
@@ -14,6 +17,9 @@ RUN npx prisma generate && npm run build
 FROM node:20-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
+
+# Prisma precisa de OpenSSL/libc6-compat em runtime (migrate deploy + query engine).
+RUN apk add --no-cache openssl libc6-compat
 
 # Apenas dependências de produção (inclui prisma CLI e tsx para migrate/seed no boot)
 COPY package*.json ./


### PR DESCRIPTION
Correção descoberta ao **rodar a stack completa** (`docker compose up --build`).

## Problema
Na imagem `node:20-alpine`, o Prisma não consegue detectar o OpenSSL e o `prisma migrate deploy` do entrypoint falha (`Could not parse schema engine response`), deixando o container `helpdesk-backend` em loop de restart.

## Correção
`apk add --no-cache openssl libc6-compat` nos estágios de build e runtime do `backend/Dockerfile`.

## Validado
Após o fix, `docker compose up --build` sobe tudo: migrations aplicadas (inclui `add_comments_and_attachments`), seed executado, e smoke test verde — login, criar chamado, `GET /tickets` com `dueAt`/`slaBreached`, `GET /tickets/stats`, ownership (403) e frontend HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)