### PR TITLE
feat(users): admin cria operador/gestor/solicitante

### DIFF
--- a/backend/src/controllers/users.controller.ts
+++ b/backend/src/controllers/users.controller.ts
@@ -1,8 +1,30 @@
 import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import { PrismaClient, UserRole } from "@prisma/client";
+import { createUsersService } from "../services/users.service";
+
+export const createUserSchema = z.object({
+  name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  email: z.string().email("E-mail inválido"),
+  password: z.string().min(6, "Senha deve ter pelo menos 6 caracteres"),
+  role: z.nativeEnum(UserRole, {
+    errorMap: () => ({ message: "Papel deve ser ADMIN, MANAGER, OPERATOR ou REQUESTER" }),
+  }),
+});
 
 export function createUsersController(prisma: PrismaClient) {
+  const usersService = createUsersService(prisma);
+
   return {
+    async create(req: Request, res: Response, next: NextFunction) {
+      try {
+        const user = await usersService.create(req.body);
+        return res.status(201).json(user);
+      } catch (err) {
+        return next(err);
+      }
+    },
+
     async listByRole(req: Request, res: Response, next: NextFunction) {
       try {
         const { role } = req.query as { role?: string };
@@ -21,19 +43,7 @@ export function createUsersController(prisma: PrismaClient) {
           });
         }
 
-        const users = await prisma.user.findMany({
-          where: {
-            role: role as UserRole,
-            active: true,
-          },
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            role: true,
-          },
-        });
-
+        const users = await usersService.listByRole(role as UserRole);
         return res.status(200).json(users);
       } catch (err) {
         return next(err);

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -1,11 +1,23 @@
 import { Router } from "express";
+import { UserRole } from "@prisma/client";
 import { authenticate } from "../middleware/authenticate";
-import { createUsersController } from "../controllers/users.controller";
+import { authorize } from "../middleware/authorize";
+import { validateBody } from "../middleware/validate";
+import { createUsersController, createUserSchema } from "../controllers/users.controller";
 import { prisma } from "../config/prisma";
 
 const usersController = createUsersController(prisma);
 
 export const usersRouter = Router();
+
+// POST - Criar usuário com papel definido (somente ADMIN)
+usersRouter.post(
+  "/",
+  authenticate,
+  authorize(UserRole.ADMIN),
+  validateBody(createUserSchema),
+  (req, res, next) => usersController.create(req, res, next),
+);
 
 // GET - Listar usuários por role (qualquer autenticado)
 usersRouter.get(

--- a/backend/src/services/users.service.ts
+++ b/backend/src/services/users.service.ts
@@ -1,0 +1,45 @@
+import { PrismaClient, User, UserRole } from "@prisma/client";
+import { hashService } from "./hash.service";
+import { ConflictError } from "../utils/errors";
+
+export type CreateUserInput = {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+};
+
+// Usuário "público" — nunca devolvemos o passwordHash.
+export type PublicUser = Pick<User, "id" | "name" | "email" | "role">;
+
+export type UsersService = ReturnType<typeof createUsersService>;
+
+export function createUsersService(prisma: PrismaClient) {
+  return {
+    async create(input: CreateUserInput): Promise<PublicUser> {
+      const existing = await prisma.user.findUnique({ where: { email: input.email } });
+      if (existing) {
+        throw new ConflictError("Já existe um usuário com este e-mail");
+      }
+
+      const passwordHash = await hashService.hash(input.password);
+      const user = await prisma.user.create({
+        data: {
+          name: input.name,
+          email: input.email,
+          passwordHash,
+          role: input.role,
+        },
+      });
+
+      return { id: user.id, name: user.name, email: user.email, role: user.role };
+    },
+
+    async listByRole(role: UserRole): Promise<PublicUser[]> {
+      return prisma.user.findMany({
+        where: { role, active: true },
+        select: { id: true, name: true, email: true, role: true },
+      });
+    },
+  };
+}

--- a/backend/tests/unit/users.service.test.ts
+++ b/backend/tests/unit/users.service.test.ts
@@ -1,0 +1,117 @@
+import { createUsersService } from "../../src/services/users.service";
+import { hashService } from "../../src/services/hash.service";
+import { ConflictError } from "../../src/utils/errors";
+import { UserRole } from "@prisma/client";
+
+type UserRow = {
+  id: string;
+  name: string;
+  email: string;
+  passwordHash: string;
+  role: UserRole;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function makePrismaMock() {
+  const store = new Map<string, UserRow>();
+  return {
+    store,
+    user: {
+      findUnique: jest.fn(async ({ where }: { where: { email: string } }) => {
+        for (const u of store.values()) {
+          if (u.email === where.email) return u;
+        }
+        return null;
+      }),
+      create: jest.fn(async ({ data }: { data: Omit<UserRow, "id" | "createdAt" | "updatedAt" | "active"> }) => {
+        const now = new Date();
+        const row: UserRow = {
+          id: `u-${store.size + 1}`,
+          name: data.name,
+          email: data.email,
+          passwordHash: data.passwordHash,
+          role: data.role,
+          active: true,
+          createdAt: now,
+          updatedAt: now,
+        };
+        store.set(row.id, row);
+        return row;
+      }),
+      findMany: jest.fn(async ({ where }: { where: { role: UserRole; active: boolean } }) =>
+        Array.from(store.values())
+          .filter((u) => u.role === where.role && u.active === where.active)
+          .map((u) => ({ id: u.id, name: u.name, email: u.email, role: u.role })),
+      ),
+    },
+  };
+}
+
+describe("usersService", () => {
+  const baseInput = {
+    name: "Carlos Operador",
+    email: "carlos@helpdesk.local",
+    password: "helpdesk123",
+    role: UserRole.OPERATOR,
+  };
+
+  it("cria usuário com o papel informado e hash de senha, sem devolver passwordHash", async () => {
+    const prisma = makePrismaMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = createUsersService(prisma as any);
+
+    const user = await service.create(baseInput);
+
+    expect(user).toEqual({
+      id: expect.any(String),
+      name: "Carlos Operador",
+      email: "carlos@helpdesk.local",
+      role: UserRole.OPERATOR,
+    });
+    expect((user as Record<string, unknown>).passwordHash).toBeUndefined();
+
+    // a senha foi de fato hasheada
+    const stored = prisma.store.get(user.id)!;
+    expect(stored.passwordHash).not.toBe(baseInput.password);
+    await expect(hashService.compare(baseInput.password, stored.passwordHash)).resolves.toBe(true);
+  });
+
+  it("respeita o papel escolhido (MANAGER / REQUESTER)", async () => {
+    const prisma = makePrismaMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = createUsersService(prisma as any);
+
+    const manager = await service.create({ ...baseInput, email: "m@helpdesk.local", role: UserRole.MANAGER });
+    const requester = await service.create({ ...baseInput, email: "r@helpdesk.local", role: UserRole.REQUESTER });
+
+    expect(manager.role).toBe(UserRole.MANAGER);
+    expect(requester.role).toBe(UserRole.REQUESTER);
+  });
+
+  it("lança ConflictError quando o e-mail já existe", async () => {
+    const prisma = makePrismaMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = createUsersService(prisma as any);
+
+    await service.create(baseInput);
+
+    await expect(service.create(baseInput)).rejects.toThrow(ConflictError);
+  });
+
+  it("listByRole retorna apenas usuários ativos do papel pedido", async () => {
+    const prisma = makePrismaMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = createUsersService(prisma as any);
+
+    await service.create({ ...baseInput, email: "op1@helpdesk.local", role: UserRole.OPERATOR });
+    await service.create({ ...baseInput, email: "op2@helpdesk.local", role: UserRole.OPERATOR });
+    await service.create({ ...baseInput, email: "mgr@helpdesk.local", role: UserRole.MANAGER });
+
+    const operators = await service.listByRole(UserRole.OPERATOR);
+
+    expect(operators).toHaveLength(2);
+    expect(operators.every((u) => u.role === UserRole.OPERATOR)).toBe(true);
+  });
+});

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRequireAuth } from "@/lib/use-require-auth";
+import { createUser, type PublicUser } from "@/lib/users";
+import { messageFromError } from "@/lib/api";
+import { ADMIN_ROLES, ASSIGNABLE_ROLES, roleLabel, type UserRole } from "@/lib/rbac";
+
+const ROLE_OPTIONS: { value: UserRole; label: string; hint: string }[] = ASSIGNABLE_ROLES.map(
+  (role) => ({
+    value: role,
+    label: roleLabel(role),
+    hint: {
+      OPERATOR: "Atende e resolve chamados na fila.",
+      MANAGER: "Acompanha indicadores e atribui chamados.",
+      REQUESTER: "Abre chamados e vê apenas os próprios.",
+      ADMIN: "Acesso total, incluindo gestão de usuários.",
+    }[role],
+  }),
+);
+
+const EMPTY = { name: "", email: "", password: "", role: "OPERATOR" as UserRole };
+
+export default function AdminUsersPage() {
+  const { user, authorized } = useRequireAuth(ADMIN_ROLES);
+
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState(EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<PublicUser[]>([]);
+
+  if (!authorized || !user) {
+    return <div className="text-sm text-slate-500">Verificando sessão…</div>;
+  }
+
+  const set = (patch: Partial<typeof form>) => setForm((f) => ({ ...f, ...patch }));
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (form.name.trim().length < 2) return setError("Informe o nome completo.");
+    if (!form.email.includes("@")) return setError("Informe um e-mail válido.");
+    if (form.password.length < 6) return setError("A senha deve ter pelo menos 6 caracteres.");
+
+    setSubmitting(true);
+    try {
+      const novo = await createUser({
+        name: form.name.trim(),
+        email: form.email.trim(),
+        password: form.password,
+        role: form.role,
+      });
+      setCreated((prev) => [novo, ...prev]);
+      setForm({ ...EMPTY, role: form.role });
+      setShowForm(false);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Usuários</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Crie contas de operador, gestor, solicitante ou administrador.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setError(null);
+            setShowForm((v) => !v);
+          }}
+          className="shrink-0 rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500"
+        >
+          {showForm ? "Fechar" : "+ Novo usuário"}
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="mt-5 space-y-4 rounded-md border border-slate-200 bg-white p-5 shadow-sm"
+          noValidate
+        >
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-slate-700">
+              Nome
+            </label>
+            <input
+              id="name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => set({ name: e.target.value })}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              placeholder="Ex.: Carlos Manutenção"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-slate-700">
+              E-mail
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={form.email}
+              onChange={(e) => set({ email: e.target.value })}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              placeholder="carlos@helpdesk.local"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-slate-700">
+              Senha provisória
+            </label>
+            <input
+              id="password"
+              type="text"
+              required
+              minLength={6}
+              value={form.password}
+              onChange={(e) => set({ password: e.target.value })}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              placeholder="Mínimo 6 caracteres"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="role" className="block text-sm font-medium text-slate-700">
+              Papel
+            </label>
+            <select
+              id="role"
+              value={form.role}
+              onChange={(e) => set({ role: e.target.value as UserRole })}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+            >
+              {ROLE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-slate-500">
+              {ROLE_OPTIONS.find((o) => o.value === form.role)?.hint}
+            </p>
+          </div>
+
+          {error && (
+            <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? "Criando…" : "Criar usuário"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {created.length > 0 && (
+        <div className="mt-6">
+          <h2 className="text-sm font-medium text-slate-700">Criados nesta sessão</h2>
+          <ul className="mt-2 divide-y divide-slate-100 rounded-md border border-slate-200 bg-white">
+            {created.map((u) => (
+              <li key={u.id} className="flex items-center justify-between gap-3 px-4 py-3 text-sm">
+                <div>
+                  <p className="font-medium text-slate-900">{u.name}</p>
+                  <p className="text-slate-500">{u.email}</p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                  {roleLabel(u.role)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -3,7 +3,13 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
-import { canViewInsights, canViewQueue, roleLabel, type UserRole } from "@/lib/rbac";
+import {
+  canManageUsers,
+  canViewInsights,
+  canViewQueue,
+  roleLabel,
+  type UserRole,
+} from "@/lib/rbac";
 
 type NavItem = { href: string; label: string; show: (role: UserRole) => boolean };
 
@@ -11,6 +17,7 @@ const NAV: NavItem[] = [
   { href: "/dashboard", label: "Chamados", show: () => true },
   { href: "/queue", label: "Fila", show: canViewQueue },
   { href: "/insights", label: "Indicadores", show: canViewInsights },
+  { href: "/admin/users", label: "Usuários", show: canManageUsers },
 ];
 
 export function Topbar() {

--- a/frontend/src/lib/mock-db.ts
+++ b/frontend/src/lib/mock-db.ts
@@ -4,7 +4,7 @@
 // memória e são reiniciados a cada reload da página.
 
 import { ApiError } from "./api";
-import { VALID_TRANSITIONS } from "./rbac";
+import { VALID_TRANSITIONS, type UserRole } from "./rbac";
 import type {
   CreateTicketInput,
   ListTicketsFilters,
@@ -413,6 +413,32 @@ export async function uploadAttachment(
   };
   (attachments[ticketId] ??= []).push(attachment);
   return clone({ ...attachment, url }); // mantém o objectURL (não serializável via clone)
+}
+
+// Usuários criados em tempo de execução no modo demo (somem ao recarregar).
+const createdUsers: { id: string; name: string; email: string; role: UserRole }[] = [];
+
+function knownEmails(): string[] {
+  return [...Object.values(U).map((u) => u.email), ...createdUsers.map((u) => u.email)];
+}
+
+export async function createUser(input: {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}): Promise<{ id: string; name: string; email: string; role: UserRole }> {
+  const email = input.email.trim().toLowerCase();
+  if (knownEmails().some((e) => e.toLowerCase() === email)) {
+    throw new ApiError(409, "Já existe um usuário com este e-mail");
+  }
+  const user = { id: nextId("u"), name: input.name.trim(), email, role: input.role };
+  createdUsers.push(user);
+  // Operadores recém-criados passam a aparecer na atribuição de chamados.
+  if (user.role === "OPERATOR") {
+    OPERATORS.push({ id: user.id, name: user.name, email: user.email });
+  }
+  return clone(user);
 }
 
 export async function listOperators(): Promise<UserMini[]> {

--- a/frontend/src/lib/rbac.ts
+++ b/frontend/src/lib/rbac.ts
@@ -17,6 +17,10 @@ export function roleLabel(role: string): string {
 // Grupos de papéis reutilizáveis (referência estável para guards/hooks).
 export const QUEUE_ROLES: UserRole[] = ["OPERATOR", "MANAGER", "ADMIN"];
 export const INSIGHTS_ROLES: UserRole[] = ["MANAGER", "ADMIN"];
+export const ADMIN_ROLES: UserRole[] = ["ADMIN"];
+
+// Papéis que um ADMIN pode atribuir ao criar um usuário.
+export const ASSIGNABLE_ROLES: UserRole[] = ["OPERATOR", "MANAGER", "REQUESTER", "ADMIN"];
 
 // ---------------------------------------------------------------------------
 // Permissões por ação (espelham o RBAC do backend — épicos #29/#30).
@@ -62,6 +66,11 @@ export function canViewQueue(role: UserRole): boolean {
 /** Acessa o dashboard executivo de indicadores. */
 export function canViewInsights(role: UserRole): boolean {
   return role === "MANAGER" || role === "ADMIN";
+}
+
+/** Pode gerir usuários (criar operador/gestor/solicitante). Somente ADMIN. */
+export function canManageUsers(role: UserRole): boolean {
+  return role === "ADMIN";
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -1,6 +1,33 @@
 import { api } from "./api";
 import { useMock, type UserMini } from "./tickets";
+import type { UserRole } from "./rbac";
 import * as mock from "./mock-db";
+
+export type CreateUserInput = {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+};
+
+export type PublicUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+};
+
+/**
+ * Cria um usuário com papel definido. Consome `POST /users` (somente ADMIN no
+ * backend). No modo mock, registra em memória para a demo.
+ */
+export async function createUser(input: CreateUserInput): Promise<PublicUser> {
+  if (useMock) return mock.createUser(input);
+  return api<PublicUser>("/users", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
 
 function normalizeList(res: unknown): UserMini[] {
   if (Array.isArray(res)) return res as UserMini[];


### PR DESCRIPTION
Adiciona ao painel do admin um botão para **criar usuários** com papel definido (operador, gestor, solicitante ou admin).

## Backend
- **`POST /users`** restrito a `ADMIN` (`authenticate` + `authorize(ADMIN)` + Zod): cria usuário com papel escolhido, hasheia a senha (bcrypt) e **nunca devolve `passwordHash`**.
- `409` em e-mail duplicado, `403` para papéis não-admin, `400` em payload inválido.
- `users.service` (`createUser`/`listByRole`) injetável e testável — **+4 testes** (76 no total, verdes).

## Frontend
- Página **`/admin/users`** com botão **"Novo usuário"** + formulário (nome, e-mail, senha, papel). Item "Usuários" no menu **só aparece para ADMIN**; a rota é guardada por `useRequireAuth(ADMIN_ROLES)`.
- `lib/users.createUser` (real + mock) e suporte no `mock-db` para a demo offline.
- `rbac.canManageUsers` + `ASSIGNABLE_ROLES`.

## Smoke test (stack real em Docker)
- [x] ADMIN cria `carlos` OPERATOR → 201 (sem passwordHash)
- [x] `carlos` loga com a senha definida → role OPERATOR
- [x] OPERATOR tentando `POST /users` → **403**
- [x] e-mail duplicado → **409**
- [x] `npm test` 76 verdes · backend/frontend build OK · lint limpo · `/admin/users` HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)